### PR TITLE
Publish multiarch image

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -71,10 +71,13 @@ jobs:
       - uses: aws-actions/amazon-ecr-login@v2
         id: login-ecr
       # Build and push docker image to container repo
-      - name: docker build and push
+      - name: docker build and push (multiarch)
         run: |
-          docker build -t $REGISTRY/$REPOSITORY:${{ env.IMAGE_TAG }} .
-          docker push $REGISTRY/$REPOSITORY:${{ env.IMAGE_TAG }}
+          docker buildx create --use
+          docker buildx build \
+          --platform linux/amd64,linux/arm64 \
+          -t $REGISTRY/$REPOSITORY:${{ env.IMAGE_TAG }} \
+          --push .
         env:
           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           REPOSITORY: ${{ vars.ECR_REPOSITORY }}


### PR DESCRIPTION
Publishes  a `linux/arm64` image in addition to the default `linux/amd64` for running natively on apple chips.